### PR TITLE
Disable Speed boost on vertical and Horizontal scrolling on Zuk, this is eating battery

### DIFF
--- a/msm8996-common/proprietary/vendor/etc/perf/perfboostsconfig.xml
+++ b/msm8996-common/proprietary/vendor/etc/perf/perfboostsconfig.xml
@@ -27,7 +27,7 @@
 
         <!-- Type="1", main launch boost of 2sec -->
         <Config
-            Id="0x00001081" Type="1" Enable="true" Timeout="2000" Target="msm8996"
+            Id="0x00001081" Type="1" Enable="false" Timeout="2000" Target="msm8996"
             Resources="0x40C00000, 0x1, 0x40804000, 0xFFF, 0x40804100, 0xFFF, 0x40800000, 0xFFF,
                        0x40800100, 0xFFF, 0x41800000, 140, 0x40400000, 0x1, 0x42C10000, 0x1" />
 
@@ -54,7 +54,7 @@
 
         <!-- Type="1", Vertical Scroll boost -->
         <Config
-            Id="0x00001080" Type="1" Enable="true" Target="msm8996"
+            Id="0x00001080" Type="1" Enable="false" Target="msm8996"
             Resources="0x41800000, 0x33, 0x40800000, 1000, 0x40800100, 1000, 0x40C00000, 0x1,
                        0x40C28000, 0x1" />
 
@@ -63,7 +63,7 @@
 
         <!-- Type="2", Horizontal Scroll boost -->
         <Config
-            Id="0x00001080" Type="2" Enable="true" Target="msm8996"
+            Id="0x00001080" Type="2" Enable="false" Target="msm8996"
             Resources="0x40C00000, 0x1" />
     </PerfBoost>
 </BoostConfigs>


### PR DESCRIPTION
…this is present on Oneplus3 which has UFS, AMOLED to save power.

Our device does not!

The entire perf folder can be removed from vendor tree by removing the entries from msm8996-common-vendor.mk without affecting the responsiveness of the device

Signed-off-by: amitwh <amit.wh@gmail.com>